### PR TITLE
Added missing data points (date and city) from faker

### DIFF
--- a/src/apps/fake-data-generator/generator.js
+++ b/src/apps/fake-data-generator/generator.js
@@ -15,6 +15,8 @@ const generators = {
     faker.fake(
       '{{address.cityPrefix}} {{address.city}}, {{address.streetName}}, {{random.number}}'
     ),
+  date: faker.date.past,
+  city: faker.address.city,
 };
 
 export const generatorsData = Object.keys(generators).map((key) => ({


### PR DESCRIPTION
Original version omitted the Date and City fields, causing missing fields in the default output and "birthday" and "city" fields to have a type of "Name".

Original:
<img width="1301" alt="Screen Shot 2020-08-18 at 11 11 38 AM" src="https://user-images.githubusercontent.com/5495386/90535975-76c97d80-e149-11ea-9f63-4117f05e6901.png">

Updated:
<img width="1318" alt="Screen Shot 2020-08-18 at 11 48 48 AM" src="https://user-images.githubusercontent.com/5495386/90536001-7cbf5e80-e149-11ea-80a6-2ce171f22f72.png">
