### PR TITLE
Replace react-color with react-colorful

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": "^2.0.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
-    "react-color": "^2.18.1",
+    "react-colorful": "^3.0.1",
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.13.1",
     "react-hot-loader": "^4.12.21",

--- a/src/components/HexInput/HexInput.jsx
+++ b/src/components/HexInput/HexInput.jsx
@@ -1,27 +1,17 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { ChromePicker as ColorPicker } from 'react-color';
-import { useIntermediateValue, useClickOutside } from 'xooks';
-import Input from '../Input/Input';
+import { useClickOutside } from 'xooks';
+import { HexColorPicker, HexColorInput } from 'react-colorful';
+import 'react-colorful/dist/index.css';
 import classes from './HexInput.styles.less';
 
 export default function HexInput({ className, value, onChange, ...others }) {
   const ref = useRef(null);
   const [opened, setOpened] = useState(false);
-  const [colorPickerValue, setColorPickerValue] = useState(value);
-  const { intermediateValue, valid, handleChange, handleSubmit } = useIntermediateValue({
-    value,
-    onChange,
-    rule: (val) => /^#[0-9A-F]{6}$/i.test(val),
-  });
-
   const closePicker = () => setOpened(false);
 
   useClickOutside(ref, closePicker);
-  useEffect(() => {
-    setColorPickerValue(value);
-  }, [value]);
 
   return (
     <div className={cx(classes.wrapper, className)} ref={ref}>
@@ -32,26 +22,9 @@ export default function HexInput({ className, value, onChange, ...others }) {
           onClick={() => setOpened((o) => !o)}
           style={{ backgroundColor: value }}
         />
-        <Input
-          {...others}
-          className={classes.input}
-          invalid={!valid}
-          type="text"
-          value={intermediateValue}
-          onChange={(event) => handleChange(event.target.value)}
-          onBlur={(event) => handleSubmit(event.target.value)}
-        />
+        <HexColorInput {...others} className={classes.input} color={value} onChange={onChange} />
       </div>
-      {opened && (
-        <div className={classes.pickerWrapper}>
-          <ColorPicker
-            className={classes.picker}
-            color={colorPickerValue}
-            onChange={(event) => setColorPickerValue(event.hex)}
-            onChangeComplete={(event) => handleChange(event.hex)}
-          />
-        </div>
-      )}
+      {opened && <HexColorPicker className={classes.picker} color={value} onChange={onChange} />}
     </div>
   );
 }

--- a/src/components/HexInput/HexInput.styles.less
+++ b/src/components/HexInput/HexInput.styles.less
@@ -15,7 +15,7 @@
 
 .input {
   height: 36px;
-  padding-left: 24px;
+  padding-left: 15px;
   padding-right: 15px;
   border: 1px solid @oc-gray-5;
   border-left: 0;

--- a/src/components/HexInput/HexInput.styles.less
+++ b/src/components/HexInput/HexInput.styles.less
@@ -14,58 +14,32 @@
 }
 
 .input {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+  height: 36px;
+  padding-left: 24px;
+  padding-right: 15px;
+  border: 1px solid @oc-gray-5;
   border-left: 0;
+  border-radius: 0 5px 5px 0;
+  background-color: @oc-white;
+
+  &:focus {
+    outline: 0;
+    border-color: @oc-violet-5;
+  }
 }
 
 .inputWrapper {
   display: flex;
-  align-items: center;
+  position: relative;
 }
 
-.pickerWrapper {
-  user-select: none;
+.picker {
   position: absolute;
   top: 40px;
   left: 0;
   z-index: 10;
-  padding: 15px;
-  border-radius: 15px;
-  border: 1px solid @oc-gray-2;
-  background-color: @oc-white;
+  border-radius: 9px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 2px 4px rgba(0, 0, 0, 0.03),
     0 4px 8px rgba(0, 0, 0, 0.03), 0 8px 16px rgba(0, 0, 0, 0.03), 0 16px 32px rgba(0, 0, 0, 0.03),
     0 32px 64px rgba(0, 0, 0, 0.03);
-
-  // removes not usable elements
-  & > div > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) {
-    display: none;
-  }
-
-  // removes padding from picker controls
-  & > div > div:nth-child(2) {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    padding-bottom: 0 !important;
-    padding-top: 10px !important;
-  }
-
-  // removes opacity track
-  & > div > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) > div:nth-child(2) {
-    display: none;
-  }
-
-  // removes margin from hue track
-  & > div > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) {
-    margin-bottom: 0 !important;
-  }
-}
-
-.picker {
-  box-shadow: none !important;
-  // removes hex input
-  :global .flexbox-fix:nth-child(2) {
-    display: none !important;
-  }
 }

--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -12,16 +12,16 @@ export default {
     },
 
     contributors: [
+      {
+        avatar:
+          'https://avatars1.githubusercontent.com/u/206567?s=460&u=e8dc0aa4202c8e3e5e43a530253297e8bab46407&v=4',
+        name: 'Vlad Shilov',
+        tg: 'https://t.me/omgovich',
+        github: 'omgovich',
+        twitter: 'omgovich',
+        website: 'https://omgovich.ru/',
+      },
       /* Become contributor and insert you name here */
-      /* template: {
-         avatar:
-           'https://avatars0.githubusercontent.com/u/10353856?s=460&u=88394dfd67727327c1f7670a1764dc38a8a24831&v=4',
-         name: 'Vitaly Rtishchev',
-         tg: 'https://t.me/rtivital',
-         github: 'rtivital',
-         twitter: 'rtivital',
-         website: 'https://github.com/rtivital',
-       } */
     ],
   },
 };

--- a/src/pages/about/Contributors/Contributors.styles.less
+++ b/src/pages/about/Contributors/Contributors.styles.less
@@ -9,6 +9,7 @@
 .image {
   width: 120px;
   height: 120px;
+  border-radius: 50%;
 }
 
 .name {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,12 @@ module.exports = {
       },
 
       {
-        test: /\.(less|css)$/,
+        test: /\.(css)$/,
+        use: ['style-loader', 'css-loader', 'postcss-loader'],
+      },
+
+      {
+        test: /\.(less)$/,
         use: [
           mode === 'production'
             ? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,11 +1042,6 @@
     update-notifier "^2.2.0"
     yargs "^8.0.2"
 
-"@icons/material@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
-  integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
-
 "@jimp/bmp@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.10.3.tgz#79a23678e8389865c62e77b0dccc3e069dfc27f0"
@@ -6539,11 +6534,6 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.0.1:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
 lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
@@ -6675,11 +6665,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-material-colors@^1.2.1:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
-  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -8857,17 +8842,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-color@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.1.tgz#2cda8cc8e06a9e2c52ad391a30ddad31972472f4"
-  integrity sha512-X5XpyJS6ncplZs74ak0JJoqPi+33Nzpv5RYWWxn17bslih+X7OlgmfpmGC1fNvdkK7/SGWYf1JJdn7D2n5gSuQ==
-  dependencies:
-    "@icons/material" "^0.2.4"
-    lodash "^4.17.11"
-    material-colors "^1.2.1"
-    prop-types "^15.5.10"
-    reactcss "^1.2.0"
-    tinycolor2 "^1.4.1"
+react-colorful@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-3.0.1.tgz#e40f9d74bdedab0ba967691405857f6e4bf1425b"
+  integrity sha512-IupMZzGFEA7g6v/a1G86M30G3ozdUcNgzWReKULk/0TWCZ6enq3loGhIWB4DKMDnH69dv4XNf/cnomXZOZljOg==
 
 react-custom-scrollbars@^4.2.1:
   version "4.2.1"
@@ -8957,13 +8935,6 @@ react@^16.13.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-reactcss@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
-  integrity sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==
-  dependencies:
-    lodash "^4.0.1"
 
 read-chunk@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Hi @rtivital! Love this project, but noticed that you're using react-color which doesn't support tree-shaking, costs you more than 140 KB, and works quite slow. Also, I saw your attempts to customize their inlined styles (it hurts).

I had the same problems several months ago and that's why I and few other guys have developed  [`react-colorful`](https://github.com/omgovich/react-colorful). It's a modern, fas and lightweight alternative to `react-color`. 

**react-colorful** is...

1. 20+ times lighter than `react-color`
2. Works waaay faster
3. Tree-shakeable
4. Has no dependencies
5. Well-tested and written in strict TS

And it fits better for your purposes because:
1. Has stand-alone `HexColorInput` component
2. Customizable (forget about `& > div > div:nth-child(2) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1)`)

I kept the default react-colorful's picker styles, but if you want to change it somehow, let me know:

![image](https://user-images.githubusercontent.com/206567/92413134-55135300-f157-11ea-92fd-adfb877d8d64.png)

Hope it helps) 
