### PR TITLE
Fix and improve copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Logo](./src/assets/logo-text.svg)
 
-Omatsuri is offline first PWA with 10 open source frontend focused tools. Omatsuri translates to «festival» from Japanese (お祭り) and here we have a small festival of applications. It was buit with strong respect to your privacy – you will never see ads and it does not include analytics services (or actually any services at all). You are highly encouraged to explore source code and use it in your projects.
+Omatsuri is offline first PWA with 10 open source frontend focused tools. Omatsuri translates to «festival» from Japanese (お祭り) and here we have a small festival of applications. It was built with strong respect to your privacy – you will never see ads and it does not include analytics services (or actually any services at all). You are highly encouraged to explore source code and use it in your projects.
 
 ## Key features
 
@@ -50,7 +50,7 @@ Omatsuri is offline first PWA with 10 open source frontend focused tools. Omatsu
 
 Thanks for taking a look at the project and thinking about contributing!
 
-To get started with application localy use these commands:
+To get started with application locally use these commands:
 
 ```sh
 # Install dependencies
@@ -64,10 +64,10 @@ Please make sure to use prettier and eslint while developing. Create awesome stu
 
 ### Features to contribute
 
-There are a lot of missing features that can be added, let's focus on most intresting:
+There are a lot of missing features that can be added, let's focus on most interesting:
 
 - Full offline support with service workers
 - Dark theme support (automatically detected from user os)
 - New application – e.g. gradient generator
 
-If you decide to build one of these featues please be aware of design language of the app and recreate it as similar as possible for new design elements.
+If you decide to build one of these features please be aware of design language of the app and recreate it as similar as possible for new design elements.

--- a/src/apps/b64-encoding/B64Encoding.jsx
+++ b/src/apps/b64-encoding/B64Encoding.jsx
@@ -63,17 +63,17 @@ export default function B64Encoding() {
         onFileAdd={(file) => handleFilesDrop([file])}
         accepts={undefined}
       >
-        Drop file to browser window to convert it to base64 format
+        Drop a file to the browser window to convert it to base64 format
       </DropPlaceholder>
       {result.content && (
         <Background className={classes.wrapper}>
           <div className={classes.section}>
-            <SettingsLabel>Raw base 64</SettingsLabel>
+            <SettingsLabel>Raw base64</SettingsLabel>
             <Highlight>{result.content}</Highlight>
           </div>
 
           <div className={classes.section}>
-            <SettingsLabel>Usage with css</SettingsLabel>
+            <SettingsLabel>Use as CSS background</SettingsLabel>
             <Highlight>{generateCssExample(result.content)}</Highlight>
           </div>
         </Background>

--- a/src/apps/svg-compressor/Output/Output.jsx
+++ b/src/apps/svg-compressor/Output/Output.jsx
@@ -11,7 +11,7 @@ export default function Output({ results }) {
     return null;
   }
 
-  const items = files.map(fileKey => {
+  const items = files.map((fileKey) => {
     if (!results[fileKey].content) {
       return null;
     }
@@ -19,7 +19,7 @@ export default function Output({ results }) {
     if (results[fileKey].error) {
       return (
         <Background key={fileKey} className={classes.wrapper}>
-          Failed to parse svg file
+          Failed to parse SVG file
         </Background>
       );
     }

--- a/src/apps/svg-compressor/SvgCompressor.jsx
+++ b/src/apps/svg-compressor/SvgCompressor.jsx
@@ -16,7 +16,7 @@ const INITIAL_PROGRESS_STATE = {
 };
 
 export default function SvgCompressor() {
-  useDocumentTitle('Svg compressor');
+  useDocumentTitle('SVG compressor');
 
   const ls = useLocalStorage({ key: '@omatsuri/svg-compressor', delay: 500 });
   const [value, setValue] = useState(ls.retrieve() || '');
@@ -97,7 +97,7 @@ export default function SvgCompressor() {
         errors={errors}
         onFilesDrop={handleFilesDrop}
         formatFileName={formatFileName}
-        dropLabel="Drop one or more svg files to start compression"
+        dropLabel="Drop one or more SVG files to start compression"
       />
       <Output results={results} />
     </>

--- a/src/apps/svg-to-jsx/SvgToJsx.jsx
+++ b/src/apps/svg-to-jsx/SvgToJsx.jsx
@@ -9,7 +9,7 @@ const svg2jsx = new Svg2jsxWorker();
 const svgProcessor = getSvgProcessor();
 
 export default function SvgToJsx() {
-  useDocumentTitle('Svg to jsx');
+  useDocumentTitle('SVG to JSX');
 
   const ls = useLocalStorage({ key: '@omatsuri/svg-to-jsx', delay: 1000 });
   const transmittedValue = useLocalStorage({ key: '@omatsuri/conversion-after-compression/jsx' });
@@ -53,7 +53,7 @@ export default function SvgToJsx() {
         onChange={handleChange}
         errors={result.error && value.trim().length > 0 ? ['input file'] : []}
         onFilesDrop={handleFilesDrop}
-        dropLabel="Drop svg file to browser window to optimize it and convert it to jsx"
+        dropLabel="Drop an SVG file to the browser window to optimize it and convert it to JSX"
       />
 
       <Output data={result} />

--- a/src/components/SvgInput/SvgInput.jsx
+++ b/src/components/SvgInput/SvgInput.jsx
@@ -26,11 +26,11 @@ export default function SvgInput({
       <DropPlaceholder onFileAdd={(file) => onFilesDrop([file])}>{dropLabel}</DropPlaceholder>
       <Background className={classes.wrapper}>
         <div className={classes.header}>
-          <SettingsLabel className={classes.title}>Paste svg markup</SettingsLabel>
+          <SettingsLabel className={classes.title}>Paste SVG markup</SettingsLabel>
           <Button onClick={() => onChange(example)}>Load example</Button>
         </div>
         <textarea
-          placeholder="Paste svg markup here"
+          placeholder="Paste SVG markup here"
           className={classes.input}
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -6,7 +6,7 @@ export default {
       avatar:
         'https://avatars0.githubusercontent.com/u/10353856?s=460&u=88394dfd67727327c1f7670a1764dc38a8a24831&v=4',
       name: 'Vitaly Rtishchev',
-      tg: 'https://t.me/rtivital',
+      tg: 'rtivital',
       github: 'rtivital',
       website: 'https://github.com/rtivital',
     },
@@ -16,7 +16,7 @@ export default {
         avatar:
           'https://avatars1.githubusercontent.com/u/206567?s=460&u=e8dc0aa4202c8e3e5e43a530253297e8bab46407&v=4',
         name: 'Vlad Shilov',
-        tg: 'https://t.me/omgovich',
+        tg: 'omgovich',
         github: 'omgovich',
         twitter: 'omgovich',
         website: 'https://omgovich.ru/',

--- a/src/data/tools.js
+++ b/src/data/tools.js
@@ -45,7 +45,7 @@ export default [
     link: '/svg-compressor',
     name: 'SVG compressor',
     description:
-      'Compress svg images with svgo tool, convert to react component immediately after if needed',
+      'Compress SVG images with SVGO tool, convert to react component immediately after if needed',
     icon: svgCompression,
   },
 
@@ -53,14 +53,14 @@ export default [
     link: '/svg-to-jsx',
     name: 'SVG → JSX',
     description:
-      'Convert svg icons and illustrations to react components (or components for other libraries with jsx support)',
+      'Convert SVG icons and illustrations to react components (or components for other libraries with JSX support)',
     icon: svg2jsx,
   },
 
   {
     link: '/b64-encoding',
     name: 'Base64 encoding',
-    description: 'Convers images or files to base64, generate styles to use as background image',
+    description: 'Convert images or files to base64, generate styles to use as background image',
     icon: b64encoding,
   },
 

--- a/src/pages/about/Application.jsx
+++ b/src/pages/about/Application.jsx
@@ -7,7 +7,7 @@ export default function Application() {
       <h2>About Omatsuri</h2>
       <p>
         Omatsuri translates to «festival» from Japanese (お祭り) and here we have a small festival
-        of applications. It was buit with strong respect to your privacy – you will never see ads
+        of applications. It was built with strong respect to your privacy – you will never see ads
         and it does not include analytics services (or actually any services at all). You are highly
         encouraged to explore <a href={settings.repository}>source code</a> and use it in your
         projects.

--- a/src/pages/about/Contributors/Contributors.jsx
+++ b/src/pages/about/Contributors/Contributors.jsx
@@ -40,7 +40,7 @@ export default function Contributors() {
           {contributor.github && (
             <a
               className={classes.socialLink}
-              href={contributor.github}
+              href={`https://github.com/${contributor.github}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -51,7 +51,7 @@ export default function Contributors() {
           {contributor.tg && (
             <a
               className={classes.socialLink}
-              href={contributor.tg}
+              href={`https://t.me/${contributor.tg}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -62,7 +62,7 @@ export default function Contributors() {
           {contributor.twitter && (
             <a
               className={classes.socialLink}
-              href={contributor.twitter}
+              href={`https://twitter.com/${contributor.twitter}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -95,7 +95,7 @@ export default function Contributors() {
           <div className={classes.social}>
             <a
               className={classes.socialLink}
-              href={author.github}
+              href={`https://github.com/${author.github}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -104,7 +104,7 @@ export default function Contributors() {
 
             <a
               className={classes.socialLink}
-              href={author.tg}
+              href={`https://t.me/${author.tg}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/pages/about/Credits.jsx
+++ b/src/pages/about/Credits.jsx
@@ -29,7 +29,7 @@ export default function Credits() {
           >
             svgo-browser
           </a>{' '}
-          tools are used for svg compression.
+          tools are used for SVG compression.
         </li>
         <li>
           Curved page dividers app was made with help of &nbsp;


### PR DESCRIPTION
1. Fixed several typos (`buit` → `built`, `localy` → `locally`, etc)
2. Fixed broken links in the authors/contributors list.
3. Consistent file format displaying everywhere (`svg|Svg` → `SVG`, etc)
4. Some minor copy improvements