### PR TITLE
Fixed Symbols 'Copied to Clipboard' status

### DIFF
--- a/src/apps/html-symbols/HtmlSymbols.jsx
+++ b/src/apps/html-symbols/HtmlSymbols.jsx
@@ -31,6 +31,7 @@ export default function HtmlSymbols() {
   const lsType = useLocalStorage({ key: '@omatsuri/html-symbols/type', delay: 200 });
   const [query, setQuery] = useState(lsQuery.retrieve() || '');
   const [type, setType] = useState(lsType.retrieve() || 'Most used');
+  const [copiedValue, setCopiedValue] = useState(null);
 
   const handleQueryChange = (event) => {
     setQuery(event.target.value);
@@ -42,14 +43,19 @@ export default function HtmlSymbols() {
     lsType.save(value);
   };
 
+  const handleCopy = (value) => {
+    setCopiedValue(value);
+    clipboard.copy(value)
+  }
+
   const results = searchSymbols(query, type).map((item) => (
     <tr className={classes.item} key={item.entity}>
       <td className={classes.name}>{item.name}</td>
       <td>
         <button
-          className={cx(classes.control, classes.symbol)}
+          className={cx(classes.control, classes.symbol, { [classes.copied]: item.symbol === copiedValue && clipboard.copied })}
           type="button"
-          onClick={() => clipboard.copy(item.symbol)}
+          onClick={() => handleCopy(item.symbol)}
         >
           {item.symbol}
         </button>
@@ -57,16 +63,18 @@ export default function HtmlSymbols() {
 
       <td>
         <button
-          className={classes.control}
+          className={cx(classes.control, { [classes.copied]: item.entity === copiedValue && clipboard.copied })}
           type="button"
-          onClick={() => clipboard.copy(item.entity)}
+          onClick={() => handleCopy(item.entity)}
         >
           {item.entity}
         </button>
       </td>
 
       <td>
-        <button className={classes.control} type="button" onClick={() => clipboard.copy(item.css)}>
+        <button className={cx(classes.control, { [classes.copied]: item.css === copiedValue && clipboard.copied })}
+          type="button"
+          onClick={() => handleCopy(item.css)}>
           {item.css}
         </button>
       </td>
@@ -85,7 +93,7 @@ export default function HtmlSymbols() {
           placeholder="Search symbols..."
         />
       </div>
-      <table className={cx(classes.results, { [classes.copied]: clipboard.copied })}>
+      <table className={classes.results}>
         <thead>
           <tr>
             <th>Name</th>

--- a/src/apps/html-symbols/HtmlSymbols.styles.less
+++ b/src/apps/html-symbols/HtmlSymbols.styles.less
@@ -66,12 +66,9 @@
 }
 
 .copied {
-  .symbol,
-  .control {
-    &::before {
-      background-color: @oc-green-7;
-      content: 'Copied to clipboard';
-    }
+  &::before {
+    background-color: @oc-green-7;
+    content: 'Copied to clipboard';
   }
 }
 
@@ -138,11 +135,8 @@
   }
 
   .copied {
-    .symbol,
-    .control {
-      &::before {
-        background-color: @oc-green-9;
-      }
+    &::before {
+      background-color: @oc-green-9;
     }
   }
 }


### PR DESCRIPTION
When an element was copied, on the _Symbols Collection_ page, the status of the action was reflected on all elements at once. 
Using the same mechanism, but with an additional check and a small CSS change, this behavior can be corrected. 

Initial behavior
![initial](https://user-images.githubusercontent.com/24988697/112062220-4d058880-8b68-11eb-897c-c239deb827f9.gif)

Updated behavior
![update](https://user-images.githubusercontent.com/24988697/112062222-4d9e1f00-8b68-11eb-8d76-94a82d8f74b5.gif)

** The green halo appearing on the elements' names is a glitch produced by the tool I used to create the GIFs 😢