### PR TITLE
feat: adding isJSX arg in share generator

### DIFF
--- a/src/apps/page-dividers/Output/generate-example.js
+++ b/src/apps/page-dividers/Output/generate-example.js
@@ -1,13 +1,16 @@
-const generateShape = (content) => (props) => `<div style="overflow: hidden;">
-  <svg
-    preserveAspectRatio="none"
-    viewBox="0 0 1200 120"
-    xmlns="http://www.w3.org/2000/svg"
-    ${props}
-  >
-    ${content}
-  </svg>
-</div>`;
+const generateShape = (content) => (props, isJSX) => {
+  return `
+  <div style=${isJSX ? "{{ overflow: 'hidden' }}" : '"overflow: hidden;"'}>
+    <svg
+      preserveAspectRatio="none"
+      viewBox="0 0 1200 120"
+      xmlns="http://www.w3.org/2000/svg"
+      ${props}
+    >
+      ${content}
+    </svg>
+  </div>`;
+};
 
 const shapes = {
   tilt: generateShape('<path d="M1200 120L0 16.48V0h1200v120z" />'),
@@ -49,14 +52,14 @@ function generateHtml(values) {
   const transformValue = getTransformValue(values);
   const transform = transformValue ? ` transform: ${transformValue};` : '';
   const style = `fill: ${values.color}; width: ${values.width}%; height: ${values.height}px;${transform}`;
-  return shapes[values.type](`style="${style}"`);
+  return shapes[values.type](`style="${style}"`, false);
 }
 
 function generateJSX(values) {
   const transformValue = getTransformValue(values);
   const transform = transformValue ? ` transform: '${transformValue}'` : '';
   const style = `fill: '${values.color}', width: '${values.width}%', height: ${values.height},${transform}`;
-  return shapes[values.type](`style={{ ${style} }}`);
+  return shapes[values.type](`style={{ ${style} }}`, true);
 }
 
 const types = {


### PR DESCRIPTION
Hello Vitaly, I didn't want to do a complete refactor of this, so I just made a small and simple change inside generateShape.

The problem was quite simple: whenever I copy the <svg> to the clipboard in JSX format, the styling is always inline CSS. So, this is just a small UX improvement.

![image](https://github.com/rtivital/omatsuri/assets/8760358/50b66e80-3418-46e7-b5c7-70f1b56bd1f7)
